### PR TITLE
Optimizations in host file generation scripts

### DIFF
--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
@@ -10,20 +10,95 @@ param(
 # Set the path to the SAP hostctrl executable
 Set-Location -Path "C:\Program Files\SAP\hostctrl\exe"
 
-# Get the hostnames of the SAP system instance
-$hosts = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function GetSystemInstanceList | Select-String -Pattern "hostname" | ForEach-Object {$_.Line.Split()[2]}
+# Get the hosts of the SAP system instance
+$hosts = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function GetSystemInstanceList
+if (!$hosts)
+{
+    Write-Output "Failed to get SAP system instances"
+    Exit 1
+}
+
+# Filter the list of hosts to get the hostnames, instance numbers and features
+$hostnames = $hosts | Select-String -Pattern "hostname" | ForEach-Object {$_.Line.Split()[2]}
+$instance_nos = $hosts | Select-String -Pattern "instanceNr" | ForEach-Object {$_.Line.Split()[2]}
+$host_features = $hosts | Select-String -Pattern "features" | ForEach-Object {$_.Line.Split()[2]}
 
 # Get the fully qualified domain name
 $fqdn = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function ParameterValue | Select-String -Pattern "SAPFQDN" | ForEach-Object {$_.Line.Split("=")[1]}
-
-$hostfile_entries = New-Object System.Collections.Generic.HashSet[string]
-
-# Loop through each hostnames
-foreach ($hostname in $hosts) {
-    $ping = Test-Connection -ComputerName $hostname -Count 1
-    $ip = $ping.IPV4Address.IPAddressToString
-    $hostfile_entries.add("$ip" + " " + "$hostname" + ".$fqdn" + " " + "$hostname")
+if (!$fqdn)
+{
+    Write-Output "Failed to get the FQDN"
+    Exit 1
 }
 
+# Declare a set to store the host file entries
+$hostfile_entries = New-Object System.Collections.Generic.HashSet[string]
+
+# Loop through the host features we have extracted
+for ($i=0; $i -lt $host_features.Length; $i++)
+{
+    $features = $host_features[$i]
+    $hostname = $hostnames[$i]
+
+    # If the current host is not an app server, get the IP address by pinging the host and add it to the host file entries
+    if (-not($features -match "ABAP"))
+    {
+        $ping = Test-Connection -ComputerName $hostname -Count 1
+        $ip = $ping.IPV4Address.IPAddressToString
+        $hostfile_entries.add("$($ip) $($hostname).$($fqdn) $($hostname)")
+    }
+
+    # If the current host is the message server, construct the URI to get the list of app servers
+    if ($features -match "MESSAGESERVER")
+    {
+        $instance_no = $instance_nos[$i]
+
+        # Add a leading zero to the instance number if it is less than 10
+        if ($instance_no -lt 10)
+        {
+            $instance_no = "0$($instance_no)"
+        }
+        $app_server_list_api = "http://$($hostname):81$($instance_no)/msgserver/xml/aslist"
+    }
+}
+
+# Call the app server list API
+try
+{
+    $app_server_response = Invoke-WebRequest -Uri $app_server_list_api
+    $http_response_code = $app_server_response.StatusCode
+
+}
+catch
+{
+    $http_response_code = $_.Exception.Response.StatusCode.value__
+}
+
+# If the API call was successful, extract the hostnames and IP addresses of the app servers and add them to the host file entries
+if ($http_response_code -eq "200")
+{
+    app_servers = ([xml]$app_server_response.Content).APPLICATION_SERVER.SERVER_LIST
+    foreach ($app_server in $app_servers.item)
+    {
+        $hostfile_entries.add("$($app_server.HOSTADR) $($app_server.HOST).$($fqdn) $($app_server.HOST)")
+    }
+}
+# If the API call was not successful, fall back to pinging the app server hosts to get the IP addresses
+else
+{
+    for ($i=0; $i -lt $hostnames.Length; $i++)
+    {
+        $features = $host_features[$i]
+        $hostname = $hostnames[$i]
+
+        # Filter to get only the app servers
+        if ($features -match "ABAP")
+        {
+            $ping = Test-Connection -ComputerName $hostname -Count 1
+            $ip = $ping.IPV4Address.IPAddressToString
+            $hostfile_entries.add("$($ip) $($hostname).$($fqdn) $($hostname)")
+        }
+    }
+}
 # Print the host file entries
 $hostfile_entries -join ", "

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
@@ -3,7 +3,7 @@
 # </copyright>
 
 param(
-[Parameter(Mandatory=$true)][int]$instanceNumber
+    [Parameter(Mandatory=$true)][string]$instanceNumber
 )
 
 # Set the path to the SAP hostctrl executable
@@ -18,7 +18,7 @@ else
 }
 
 # Get the hosts of the SAP system instance
-if (Test-Path "sapcontrol" -PathType Leaf)
+if (Test-Path ".\sapcontrol.exe" -PathType Leaf)
 {
     $hosts = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function GetSystemInstanceList
 }

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
@@ -11,20 +11,113 @@ instanceNumber=00
 cd "/usr/sap/hostctrl/exe"
 
 # Get the hostnames of the SAP system instance
-hosts=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function GetSystemInstanceList | grep "hostname" | cut -d " " -f 3)
+hosts=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function GetSystemInstanceList)
+if [[ -z "$hosts" ]]
+then
+    echo "Failed to get SAP system instances"
+    exit 1
+fi
+
+# Filter the list of hosts to get the hostnames, instance numbers and features
+hostnames=($(echo "$hosts" | grep "hostname" | cut -d " " -f 3))
+instance_nos=($(echo "$hosts" | grep "instanceNr" | cut -d " " -f 3))
+host_features=($(echo "$hosts" | grep "features" | cut -d " " -f 3))
 
 # Get the fully qualified domain name
 fqdn=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function ParameterValue | grep "SAPFQDN" | cut -d "=" -f 2 | tr -d '\r')
+if [[ -z "$fqdn" ]]
+then
+    echo "Failed to get the FQDN"
+    exit 1
+fi
 
 # Declare an array to store the host file entries
 hostfile_entries=()
 
-# Loop through each hostname
-for hostname in $hosts
+# Declare an array to store already seen hosts
+seen_hosts=()
+
+# Loop through the host features we have extracted
+for i in "${!host_features[@]}"
 do
-    ip=$(ping -c 1 $hostname | head -n 1 | cut -d "(" -f 2 | cut -d ")" -f 1)
-    hostfile_entries+="$ip $hostname.$fqdn $hostname,"
+    features=${host_features[$i]}
+    hostname=${hostnames[$i]}
+
+    # If the current host is not an app server, get the IP address by pinging the host and add it to the host file entries
+    if [[ $features != *"ABAP"* ]]
+    then
+        ip=$(ping -c 1 $hostname | head -n 1 | cut -d "(" -f 2 | cut -d ")" -f 1)
+        host_key="$ip^$hostname"
+
+        # Check that we don't add the same host twice
+        if [[ ! " ${seen_hosts[*]} " =~ [[:space:]]${host_key}[[:space:]] ]]
+        then
+            seen_hosts+=("$host_key")
+            hostfile_entries+="$ip $hostname.$fqdn $hostname,"
+        fi
+    fi
+
+    # If the current host is the message server, construct the URI to get the list of app servers
+    if [[ $features == *"MESSAGESERVER"* ]]
+    then
+        instance_no=${instance_nos[$i]}
+
+        # Add a leading zero to the instance number if it is less than 10
+        if [ $instance_no -lt 10 ]
+        then
+            instance_no="0$instance_no"
+        fi
+
+        app_server_list_uri="http://$hostname:81$instance_no/msgserver/xml/aslist"
+    fi
 done
+
+# Call the app server list API
+app_servers_response=$(curl -s -w "http_code=%{http_code}\n" "$app_server_list_uri")
+http_response_code=$(echo "$app_servers_response" | grep -oP "(?<=http_code=).*")
+
+# If the API call was successful, extract the hostnames and IP addresses of the app servers and add them to the host file entries
+if [[ "$http_response_code" == "200" ]]
+then
+    app_hostnames=($(echo "$app_servers_response" | grep -oP "(?<=<HOST>)[^<]+"))
+    app_ips=($(echo "$app_servers_response" | grep -oP "(?<=<HOSTADR>)[^<]+"))
+
+    # Loop over the extracted app server hostnames and IP addresses
+    for i in "${!app_hostnames[@]}"
+    do
+        hostname=${app_hostnames[$i]}
+        ip=${app_ips[$i]}
+        host_key="$ip^$hostname"
+
+        # Check that we don't add the same host twice
+        if [[ ! " ${seen_hosts[*]} " =~ [[:space:]]${host_key}[[:space:]] ]]
+        then
+            seen_hosts+=("$host_key")
+            hostfile_entries+="$ip $hostname.$fqdn $hostname,"
+        fi
+    done
+# If the API call was not successful, fall back to pinging the app server hosts to get the IP addresses
+else
+    for i in "${!hostnames[@]}"
+    do
+        features=${host_features[$i]}
+        hostname=${hostnames[$i]}
+
+        # Filter to get only the app servers
+        if [[ $features == *"ABAP"* ]]
+        then
+            ip=$(ping -c 1 $hostname | head -n 1 | cut -d "(" -f 2 | cut -d ")" -f 1)
+            host_key="$ip^$hostname"
+
+            # Check that we don't add the same host twice
+            if [[ ! " ${seen_hosts[*]} " =~ [[:space:]]${host_key}[[:space:]] ]]
+            then
+                seen_hosts+=("$host_key")
+                hostfile_entries+="$ip $hostname.$fqdn $hostname,"
+            fi
+        fi
+    done
+fi
 
 # Print the host file entries separated by commas
 hostfile_entries=${hostfile_entries%?}

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
@@ -5,14 +5,14 @@
 #!/bin/bash
 
 # Replace instance number with the instance number of the Central Server instance
-instanceNumber=00
+instanceNumber=$1
 
 # Set the path to the SAP hostctrl executable
 if [ -d "/usr/sap/hostctrl/exe" ]
 then
     cd "/usr/sap/hostctrl/exe"
 else
-    echo "/usr/sap/hostctrl/exe directory not found" >&2
+    echo "SAP hostctrl directory not found" >&2
     exit 1
 fi
 
@@ -21,7 +21,7 @@ if [ -x "./sapcontrol" ]
 then
 	hosts=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function GetSystemInstanceList)
 else
-    echo "'sapcontrol' not found in the path '/usr/sap/hostctrl/exe/sapcontrol'" >&2
+    echo "sapcontrol executable not found" >&2
     exit 1
 fi
 

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
@@ -17,7 +17,7 @@ Steps:
 1. On the Azure Portal, navigate to the Central Server Virtual Machine.
 2. In the search bar, type “Run Command”, select the Run Command option under Operations.
 3. Select the “RunShellScript” option, this would open a contextual pane with input box.
-4. Copy the script “GenerateHostfileMappings.sh” in the Linux Shell Script input box and replace the instance number on line 7, without any white spaces. If the instance number is connect error, the out will show stderr. 
+4. Copy the script “GenerateHostfileMappings.sh” in the Linux Shell Script input box and replace the instance number on line 8, without any white spaces. If the instance number is incorrect, you will see the corresponding error under stderr.
 5. Click the Run button, and it should take a few minutes to get the output.
 6. Check for the output format, it should have a comma separated format of IP FQDN HOSTNAME, for example: 1.2.3.4 sapserver1.domain.com sapserver1, 1.2.3.5 sapserver2.domain.com sapserver2.
 7. Copy the hostfile entries and use them while adding a provider for the system.


### PR DESCRIPTION
Made the following changes:
- Optimization to call the app server list API to fetch IP details of active app servers instead of relying on pinging each hostname separately. In case this API call fails, fall back to pinging each hostname.
- Added de-duplication in the bash script to handle cases where there may be multiple hostnames in the same VM.
- Added handling for various error scenarios.
- Updated the README accordingly.